### PR TITLE
`fix/toggle-buttons`: disable click events when sidebar is expanded

### DIFF
--- a/src/components/sidebar/floating-sidebar-toggle.tsx
+++ b/src/components/sidebar/floating-sidebar-toggle.tsx
@@ -28,7 +28,7 @@ export function FloatingSidebarToggle() {
         !isSharePage ? "block" : "hidden",
         isVisible
           ? "animate-in slide-in-from-left-12"
-          : "-translate-x-12 opacity-0",
+          : "-translate-x-12 opacity-0 invisible",
       )}
     >
       <Button


### PR DESCRIPTION
Small fix to disable click events on floating toggles when the sidebar is expanded.

fixes #41 