### PR TITLE
`fix/search-toggle`: disable search for models that don't support it

### DIFF
--- a/src/features/chat/hooks/use-chat-input-controller.ts
+++ b/src/features/chat/hooks/use-chat-input-controller.ts
@@ -63,6 +63,16 @@ export function useChatInputController({
     [selectedModel],
   );
 
+  React.useEffect(() => {
+    if (searchEnabled && !capabilities.supportsSearch) {
+      setSearchEnabled(false);
+    }
+  }, [
+    capabilities.supportsSearch,
+    searchEnabled,
+    setSearchEnabled
+  ]);
+
   const canUpload = canUploadFiles(capabilities);
   const acceptedTypes = getAcceptedFileTypes(capabilities);
 
@@ -121,8 +131,8 @@ export function useChatInputController({
   const onKeyDown = React.useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     const shouldSend
       = (keyboardShortcut === "enter" && e.key === "Enter" && !e.shiftKey && !e.ctrlKey)
-        || (keyboardShortcut === "ctrlEnter" && e.key === "Enter" && e.ctrlKey)
-        || (keyboardShortcut === "shiftEnter" && e.key === "Enter" && e.shiftKey);
+      || (keyboardShortcut === "ctrlEnter" && e.key === "Enter" && e.ctrlKey)
+      || (keyboardShortcut === "shiftEnter" && e.key === "Enter" && e.shiftKey);
 
     if (shouldSend) {
       e.preventDefault();


### PR DESCRIPTION
Updates the chat input controller to use `useEffect` to automatically toggle-off search when switching to models that don't support the tool.

fixes #35 