### PR TITLE
`fix/code-blocks`: render code with new lines as code blocks

### DIFF
--- a/src/features/chat/components/messages/markdown.tsx
+++ b/src/features/chat/components/messages/markdown.tsx
@@ -24,7 +24,9 @@ const MemoizedMarkdownBlock = memo(
         components={{
           code: ({ node, className, children, ...props }) => {
             const match = /language-(\w+)/.exec(className || "");
-            const isInline = !match;
+            const hasNewlines = String(children).includes("\n");
+            const isInline = !match && !hasNewlines;
+
             if (isInline) {
               return (
                 <code
@@ -39,7 +41,7 @@ const MemoizedMarkdownBlock = memo(
             }
             return (
               <CodeBlock
-                language={match ? match[1] : ""}
+                language={match ? match[1] : "plaintext"}
                 value={String(children).replace(/\n$/, "")}
               />
             );


### PR DESCRIPTION
This updates the markdown renderer to do 3 things:
1. Checks if a code block contains new lines, if it has any render as a block
2. Updates the code path to only treat as inline if no language and no new lines
3. Defaults the language to plain text if no language was set

Fixes #40 