### PR TITLE
chat: cache salts during message decrypt

### DIFF
--- a/src/lib/security/keys.ts
+++ b/src/lib/security/keys.ts
@@ -84,6 +84,18 @@ export async function getSaltForVersion(userId: string, version: number): Promis
   return result[0].salt;
 }
 
+/**
+ * Get all salts for a user, keyed by version.
+ */
+export async function getSaltsForUser(userId: string): Promise<Map<number, string>> {
+  const result = await db
+    .select({ version: keySalts.version, salt: keySalts.salt })
+    .from(keySalts)
+    .where(eq(keySalts.userId, userId));
+
+  return new Map(result.map(row => [row.version, row.salt]));
+}
+
 const ROTATION_BATCH_SIZE = 100;
 
 /**


### PR DESCRIPTION
Possibly closes #71, but need to test in a real environment to tell.

We used to decrypt each message by looking up the salt in the DB and re-deriving the scrypt key every time. That meant N DB lookups + N key derivations for a thread load. Now we fetch all salts for the user once, cache derived keys per key version in memory for the request, and decrypt using those cached keys. This keeps the same encryption behavior, but avoids unnecessary DB calls during thread load.

These caches are request-scoped, so they work fine on Vercel serverless without relying on cross-request memory. We could consider a shared cache (Redis/KV) later, but we’d need to weigh latency and security tradeoffs.