### PR TITLE
feat: better handle encrypted reasoning, save model_id in messages

### DIFF
--- a/src/app/(main)/chat/[id]/chat-thread.tsx
+++ b/src/app/(main)/chat/[id]/chat-thread.tsx
@@ -23,17 +23,31 @@ type ChatThreadProps = {
   initialMessages: ChatUIMessage[];
   initialPendingMessage?: any | null;
   parentThread?: { id: string; title: string } | null;
+  lastUsedModelId?: string | null;
   initialThread?: ThreadFromApi | null;
 };
 
-function ChatThread({ params, initialMessages, initialPendingMessage, parentThread, initialThread }: ChatThreadProps): React.ReactNode {
+function ChatThread({ params, initialMessages, initialPendingMessage, parentThread, lastUsedModelId, initialThread }: ChatThreadProps): React.ReactNode {
   const { id } = use(params);
   const queryClient = useQueryClient();
   const {
     clearInput,
     setInput,
     setStreamingThreadId,
+    setSelectedModelId,
   } = useChatUIStore();
+
+  // Rehydrate model selector from thread's last-used model
+  const hasRehydratedModelRef = useRef(false);
+  useEffect(() => {
+    if (hasRehydratedModelRef.current)
+      return;
+    hasRehydratedModelRef.current = true;
+
+    if (lastUsedModelId) {
+      setSelectedModelId(lastUsedModelId);
+    }
+  }, [lastUsedModelId, setSelectedModelId]);
 
   // Handle handoff prompt from sessionStorage
   const hasSetHandoffPromptRef = useRef(false);

--- a/src/app/(main)/chat/[id]/page.tsx
+++ b/src/app/(main)/chat/[id]/page.tsx
@@ -49,12 +49,19 @@ export default async function ChatServer({ params }: ChatServerProps) {
   // The client component (chat-thread.tsx) will retrieve it from sessionStorage.
   const initialPendingMessage: UIMessage | null = null;
 
+  // Derive the last-used model from the most recent user message that has a modelId
+  const lastUsedModelId = initialMessages
+    .filter(m => m.role === "user" && m.modelId)
+    .at(-1)
+    ?.modelId ?? null;
+
   return (
     <ChatThread
       params={Promise.resolve({ id })}
       initialMessages={initialMessages}
       initialPendingMessage={initialPendingMessage}
       parentThread={parentThread}
+      lastUsedModelId={lastUsedModelId}
       initialThread={
         thread
           ? {

--- a/src/features/chat/components/chat-messages.tsx
+++ b/src/features/chat/components/chat-messages.tsx
@@ -159,9 +159,10 @@ export const ChatMessages = memo(({
 
         if (message.role === "user") {
           const nextMessage = filteredMessages[messageIndex + 1];
-          const previousModelId = nextMessage?.role === "assistant"
-            ? (nextMessage.metadata?.model || nextMessage.stoppedModelId || stoppedAssistantMessageInfoById[nextMessage.id]?.modelId || null)
-            : null;
+          const previousModelId = message.modelId
+            || (nextMessage?.role === "assistant"
+              ? (nextMessage.metadata?.model || nextMessage.stoppedModelId || stoppedAssistantMessageInfoById[nextMessage.id]?.modelId || null)
+              : null);
 
           return (
             <EditableUserMessage

--- a/src/features/chat/queries.ts
+++ b/src/features/chat/queries.ts
@@ -91,6 +91,7 @@ export const getMessagesByThreadId = cache(async (threadId: string): Promise<Cha
       keyVersion: messages.keyVersion,
       searchEnabled: messages.searchEnabled,
       reasoningLevel: messages.reasoningLevel,
+      modelId: messages.modelId,
       // Metadata from message_metadata table
       metaModel: messageMetadata.model,
       metaInputTokens: messageMetadata.inputTokens,
@@ -156,6 +157,7 @@ export const getMessagesByThreadId = cache(async (threadId: string): Promise<Cha
       id: row.id,
       searchEnabled: row.searchEnabled,
       reasoningLevel: row.reasoningLevel,
+      modelId: row.modelId,
       metadata,
     };
   }));
@@ -170,13 +172,14 @@ export const getMessagesByThreadId = cache(async (threadId: string): Promise<Cha
  * @param options Optional settings
  * @param options.searchEnabled Whether search was enabled for this message
  * @param options.reasoningLevel The reasoning level used for this message
+ * @param options.modelId The model ID used for this message
  * @return {Promise<void>}
  */
 export async function saveMessage(
   threadId: string,
   userId: string,
   message: ChatUIMessage,
-  options?: { searchEnabled?: boolean; reasoningLevel?: string },
+  options?: { searchEnabled?: boolean; reasoningLevel?: string; modelId?: string },
 ): Promise<void> {
   const dateNow = new Date();
 
@@ -205,6 +208,7 @@ export async function saveMessage(
       keyVersion: keyMeta.version,
       searchEnabled: options?.searchEnabled,
       reasoningLevel: options?.reasoningLevel,
+      modelId: options?.modelId,
     });
 
     // Insert metadata for assistant messages (user messages don't have cost/token info)

--- a/src/features/chat/server/handler.ts
+++ b/src/features/chat/server/handler.ts
@@ -72,7 +72,7 @@ export async function handleChatRequest({ req, userId }: { req: Request; userId:
   if (threadId && !isRegeneration) {
     const lastMessage = messages[messages.length - 1];
     if (lastMessage?.role === "user") {
-      saveMessage(threadId, userId, lastMessage, { searchEnabled, reasoningLevel })
+      saveMessage(threadId, userId, lastMessage, { searchEnabled, reasoningLevel, modelId: baseModelId })
         .catch((error) => {
           console.error("Failed to save user message", error);
         });

--- a/src/features/chat/types.ts
+++ b/src/features/chat/types.ts
@@ -244,4 +244,5 @@ export type ChatUIMessage = UIMessage<MessageMetadata> & {
   stoppedModelId?: string | null;
   searchEnabled?: boolean | null;
   reasoningLevel?: string | null;
+  modelId?: string | null;
 };

--- a/src/lib/db/migrations/0005-message-model-id.sql
+++ b/src/lib/db/migrations/0005-message-model-id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "messages" ADD COLUMN "model_id" text;

--- a/src/lib/db/schema/chat.ts
+++ b/src/lib/db/schema/chat.ts
@@ -53,6 +53,7 @@ export const messages = pgTable(
     keyVersion: integer("key_version"),
     reasoningLevel: text("reasoning_level"),
     searchEnabled: boolean("search_enabled"),
+    modelId: text("model_id"),
     createdAt: timestamp("created_at").defaultNow().notNull(),
   },
   table => [index("messages_threadId_idx").on(table.threadId)],


### PR DESCRIPTION
This handles two bugs:

1. The error ```Anthropic: messages.1.content.0: Invalid `signature` in `thinking` block``` would occasionally pop up. A similar message showed with Google on occasion. Previously, we stripped out some reasoning data before saving it to the database, as it was massive and didn't feel worth saving. Turns out, it was important. Whoops.
2. Some users reported the model of the newly sent message didn't match the initially selected model. For instance, sending a message with Opus 4.5 enabled would return a message from GPT 5.2. Weird. My research points to some type of override globally. We persist `selectedModelId` globally, so if another view of action changes it (the inline editor? Another tab maybe?), the next send will use that model. We now persist the model per-message, and use the previously used messageId as the default, to *hopefully* fix any weird state mismatches. I was never able to get a repro of this issue, but here's hoping this handles it.