### PR TITLE
settings: better handle accent color, use true hue

### DIFF
--- a/src/features/settings/components/settings-page.tsx
+++ b/src/features/settings/components/settings-page.tsx
@@ -15,8 +15,9 @@ import {
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 
+import { applyAccentColor } from "~/components/theme/theme-initializer";
 import { Button } from "~/components/ui/button";
 import { Separator } from "~/components/ui/separator";
 import {
@@ -28,6 +29,7 @@ import {
 } from "~/components/ui/sheet";
 import { Skeleton } from "~/components/ui/skeleton";
 import { signOut, useSession } from "~/features/auth/lib/auth-client";
+import { useUserSettings } from "~/features/settings/hooks/use-user-settings";
 import { usePreviousRoute } from "~/features/settings/previous-route-context";
 import { cn } from "~/lib/utils";
 
@@ -76,9 +78,18 @@ export function SettingsPage({ initialTab = "interface" }: SettingsPageProps) {
   const [activeTab, setActiveTab] = useState<TabId>(initialTab);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
+  const { data: settings } = useUserSettings({ enabled: true });
+
   const tabsRef = useRef<HTMLDivElement>(null);
   const [canScrollLeft, setCanScrollLeft] = useState(false);
   const [canScrollRight, setCanScrollRight] = useState(false);
+
+  // Apply accent color before paint to prevent flicker
+  useLayoutEffect(() => {
+    if (settings?.accentColor) {
+      applyAccentColor(settings.accentColor);
+    }
+  }, [settings?.accentColor]);
 
   const updateScrollState = useCallback(() => {
     const el = tabsRef.current;

--- a/src/features/settings/components/tabs/interface-tab.tsx
+++ b/src/features/settings/components/tabs/interface-tab.tsx
@@ -62,19 +62,6 @@ const accentColorOptions: { value: AccentColorPreset; color: string; label: stri
   { value: "gray", color: "#888888", label: "Gray" },
 ];
 
-function hueToHex(hue: number): string {
-  const h = hue / 360;
-  const s = 0.7;
-  const l = 0.55;
-  const a = s * Math.min(l, 1 - l);
-  const f = (n: number) => {
-    const k = (n + h * 12) % 12;
-    const color = l - a * Math.max(Math.min(k - 3, 9 - k, 1), -1);
-    return Math.round(255 * color).toString(16).padStart(2, "0");
-  };
-  return `#${f(0)}${f(8)}${f(4)}`;
-}
-
 export function InterfaceTab() {
   const { data: settings, isLoading } = useUserSettings({ enabled: true });
   const updatePreferences = useUpdatePreferences();
@@ -180,7 +167,7 @@ export function InterfaceTab() {
               <div className="flex items-center gap-3">
                 <div
                   className="h-6 w-6 shrink-0 rounded-full border"
-                  style={{ backgroundColor: hueToHex(localHue ?? settings.accentColor) }}
+                  style={{ backgroundColor: `oklch(0.72 0.19 ${localHue ?? settings.accentColor})` }}
                 />
                 <input
                   type="range"
@@ -202,7 +189,7 @@ export function InterfaceTab() {
                     h-2 w-full cursor-pointer appearance-none rounded-full
                   `}
                   style={{
-                    background: "linear-gradient(to right, hsl(0 70% 55%), hsl(60 70% 55%), hsl(120 70% 55%), hsl(180 70% 55%), hsl(240 70% 55%), hsl(300 70% 55%), hsl(360 70% 55%))",
+                    background: "linear-gradient(to right, oklch(0.72 0.19 0), oklch(0.72 0.19 60), oklch(0.72 0.19 120), oklch(0.72 0.19 180), oklch(0.72 0.19 240), oklch(0.72 0.19 300), oklch(0.72 0.19 360))",
                   }}
                 />
                 <span className="text-muted-foreground w-8 text-xs">


### PR DESCRIPTION
Fixes #110 and a personal grievance of mine.

### Before:
<img width="314" height="112" alt="image" src="https://github.com/user-attachments/assets/427e5e72-4abc-4552-b3b0-23e53c1c8188" />

The color on the slider, the color indicator next to the slider, and the actual theme color do not match.

### After:
<img width="314" height="112" alt="image" src="https://github.com/user-attachments/assets/87f8a30a-588c-45bc-a825-bf638533284c" />

Beauty.