### PR TITLE
chat: scope attachments to chat input (fix global attachment state)

### DIFF
--- a/src/features/attachments/hooks/use-file-attachments.ts
+++ b/src/features/attachments/hooks/use-file-attachments.ts
@@ -19,17 +19,27 @@ type UseFileAttachmentsProps = {
   onValueChange: (value: string) => void;
   textareaRef: React.RefObject<HTMLTextAreaElement | null>;
   autoCreateFilesFromPaste?: boolean;
+  localPendingFiles?: {
+    files: PendingFile[];
+    setFiles: (next: PendingFile[] | ((prev: PendingFile[]) => PendingFile[])) => void;
+    clear: () => void;
+  };
 };
 
 export function useFileAttachments({
   capabilities,
   autoCreateFilesFromPaste = true,
+  localPendingFiles,
 }: UseFileAttachmentsProps) {
   const queryClient = useQueryClient();
   const fileInputRef = React.useRef<HTMLInputElement>(null);
-  const pendingFiles = useChatUIStore(s => s.pendingFiles);
-  const setPendingFiles = useChatUIStore(s => s.setPendingFiles);
-  const storeClearPendingFiles = useChatUIStore(s => s.clearPendingFiles);
+  const globalPendingFiles = useChatUIStore(s => s.pendingFiles);
+  const globalSetPendingFiles = useChatUIStore(s => s.setPendingFiles);
+  const globalClearPendingFiles = useChatUIStore(s => s.clearPendingFiles);
+
+  const pendingFiles = localPendingFiles ? localPendingFiles.files : globalPendingFiles;
+  const setPendingFiles = localPendingFiles ? localPendingFiles.setFiles : globalSetPendingFiles;
+  const storeClearPendingFiles = localPendingFiles ? localPendingFiles.clear : globalClearPendingFiles;
 
   const uploadFiles = React.useCallback(
     async (filesToUpload: FileList | File[]) => {

--- a/src/features/chat/components/messages/inline-message-editor.tsx
+++ b/src/features/chat/components/messages/inline-message-editor.tsx
@@ -78,6 +78,19 @@ export function InlineMessageEditor({
   const canUpload = canUploadFiles(capabilities);
   const acceptedTypes = getAcceptedFileTypes(capabilities);
 
+  const [localFiles, setLocalFiles] = React.useState<PendingFile[]>([]);
+  const localPendingFiles = React.useMemo(() => ({
+    files: localFiles,
+    setFiles: setLocalFiles,
+    clear: () => {
+      for (const f of localFiles) {
+        if (f.url?.startsWith("blob:"))
+          URL.revokeObjectURL(f.url);
+      }
+      setLocalFiles([]);
+    },
+  }), [localFiles]);
+
   const {
     pendingFiles,
     fileInputRef,
@@ -91,6 +104,7 @@ export function InlineMessageEditor({
     onValueChange: setContent,
     textareaRef,
     autoCreateFilesFromPaste: settings?.autoCreateFilesFromPaste ?? true,
+    localPendingFiles,
   });
 
   React.useEffect(() => {


### PR DESCRIPTION
Closes #124 

I eventually want to do an attachments refactor, but that's for another time.