### PR TITLE
chat: remove marked dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -48,7 +48,6 @@
         "fuse.js": "^7.1.0",
         "input-otp": "^1.4.2",
         "lucide-react": "^0.562.0",
-        "marked": "^17.0.1",
         "next": "16.1.1",
         "next-themes": "^0.4.6",
         "pdf-lib": "^1.17.1",
@@ -1580,8 +1579,6 @@
     "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
 
     "markdown-to-jsx": ["markdown-to-jsx@8.0.0", "", { "peerDependencies": { "react": ">= 0.14.0" }, "optionalPeers": ["react"] }, "sha512-hWEaRxeCDjes1CVUQqU+Ov0mCqBqkGhLKjL98KdbwHSgEWZZSJQeGlJQatVfeZ3RaxrfTrZZ3eczl2dhp5c/pA=="],
-
-    "marked": ["marked@17.0.1", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, ""],
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "fuse.js": "^7.1.0",
     "input-otp": "^1.4.2",
     "lucide-react": "^0.562.0",
-    "marked": "^17.0.1",
     "next": "16.1.1",
     "next-themes": "^0.4.6",
     "pdf-lib": "^1.17.1",

--- a/src/features/chat/components/messages/markdown-math-block.tsx
+++ b/src/features/chat/components/messages/markdown-math-block.tsx
@@ -1,0 +1,24 @@
+import type { Components } from "react-markdown";
+
+import ReactMarkdown from "react-markdown";
+import rehypeKatex from "rehype-katex";
+import remarkGfm from "remark-gfm";
+import remarkMath from "remark-math";
+
+export default function MathMarkdownBlock({
+  content,
+  components,
+}: {
+  content: string;
+  components: Partial<Components>;
+}) {
+  return (
+    <ReactMarkdown
+      remarkPlugins={[remarkGfm, remarkMath]}
+      rehypePlugins={[rehypeKatex]}
+      components={components}
+    >
+      {content}
+    </ReactMarkdown>
+  );
+}

--- a/src/features/chat/components/messages/markdown.tsx
+++ b/src/features/chat/components/messages/markdown.tsx
@@ -1,91 +1,166 @@
 /* eslint-disable react/no-array-index-key */
-import { marked } from "marked";
 import Link from "next/link";
-import { memo, useMemo } from "react";
+import { lazy, memo, Suspense, useMemo } from "react";
 import ReactMarkdown from "react-markdown";
-import rehypeKatex from "rehype-katex";
 import remarkGfm from "remark-gfm";
-import remarkMath from "remark-math";
 
 import { CodeBlock } from "~/features/chat/components/messages/code-block";
 import { cn } from "~/lib/utils";
 
-function parseMarkdownIntoBlocks(markdown: string): string[] {
-  const tokens = marked.lexer(markdown);
-  const blocks: string[] = [];
+const MathMarkdownBlock = lazy(() => import("./markdown-math-block"));
 
-  for (const token of tokens) {
-    const parts = token.raw.split(/(^\$\$[\s\S]*?\$\$$)/m);
-    for (const part of parts) {
-      const trimmed = part.trim();
-      if (!trimmed)
-        continue;
-      const displayMatch = trimmed.match(/^\$\$([\s\S]*?)\$\$$/);
-      if (displayMatch) {
-        blocks.push(`$$\n${displayMatch[1].trim()}\n$$`);
-      }
-      else {
-        blocks.push(trimmed);
-      }
+function parseMarkdownIntoBlocks(markdown: string): string[] {
+  const lines = markdown.split("\n");
+  const blocks: string[] = [];
+  let current: string[] = [];
+  let inCodeFence = false;
+  let fenceMarker = "";
+  let inMath = false;
+
+  function flush() {
+    if (current.length > 0) {
+      const block = current.join("\n").trim();
+      if (block)
+        blocks.push(block);
+      current = [];
     }
   }
 
-  return blocks;
+  for (const line of lines) {
+    // Code fence toggle
+    if (!inMath) {
+      const fenceMatch = line.match(/^(`{3,}|~{3,})/);
+      if (fenceMatch) {
+        if (!inCodeFence) {
+          flush();
+          inCodeFence = true;
+          fenceMarker = fenceMatch[1][0].repeat(fenceMatch[1].length);
+          current.push(line);
+          continue;
+        }
+        else if (line.startsWith(fenceMarker) && line.trim() === fenceMarker) {
+          current.push(line);
+          flush();
+          inCodeFence = false;
+          fenceMarker = "";
+          continue;
+        }
+      }
+    }
+
+    if (inCodeFence) {
+      current.push(line);
+      continue;
+    }
+
+    // Math block toggle
+    if (!inMath && line.trimStart().startsWith("$$")) {
+      const afterOpen = line.trimStart().slice(2);
+      if (afterOpen.trimEnd().endsWith("$$") && afterOpen.trimEnd().length > 2) {
+        // Single-line display math: $$...$$
+        flush();
+        const inner = afterOpen.trimEnd().slice(0, -2).trim();
+        blocks.push(`$$\n${inner}\n$$`);
+        continue;
+      }
+      flush();
+      inMath = true;
+      current.push(line);
+      continue;
+    }
+
+    if (inMath) {
+      current.push(line);
+      if (line.trimEnd().endsWith("$$")) {
+        // Normalize: put $$ on own lines
+        const raw = current.join("\n");
+        const inner = raw.replace(/^\s*\$\$/, "").replace(/\$\$\s*$/, "").trim();
+        blocks.push(`$$\n${inner}\n$$`);
+        current = [];
+        inMath = false;
+      }
+      continue;
+    }
+
+    // Empty line = paragraph break
+    if (line.trim() === "") {
+      flush();
+      continue;
+    }
+
+    current.push(line);
+  }
+
+  flush();
+  return blocks.length > 0 ? blocks : [markdown];
 }
+
+const MATH_RE = /\$\$?/;
+
+const markdownComponents = {
+  code: ({ className, children, ...props }: { node?: unknown; className?: string; children?: React.ReactNode }) => {
+    const match = /language-(\w+)/.exec(className || "");
+    const hasNewlines = String(children).includes("\n");
+    const isInline = !match && !hasNewlines;
+
+    if (isInline) {
+      return (
+        <code
+          className={cn(
+            "bg-muted rounded px-1.5 py-0.5 font-mono text-xs",
+          )}
+          {...props}
+        >
+          {children}
+        </code>
+      );
+    }
+    return (
+      <CodeBlock
+        language={match ? match[1] : "plaintext"}
+        value={String(children).replace(/\n$/, "")}
+      />
+    );
+  },
+  pre: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+  a: ({ href, children }: { href?: string; children?: React.ReactNode }) => (
+    <Link
+      href={href || "#"}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={`
+        text-primary underline underline-offset-2
+        hover:no-underline
+      `}
+    >
+      {children}
+    </Link>
+  ),
+  table: ({ children }: { children?: React.ReactNode }) => (
+    <div className="mb-3 overflow-x-auto">
+      <table className="w-full border-collapse text-sm">
+        {children}
+      </table>
+    </div>
+  ),
+};
 
 const MemoizedMarkdownBlock = memo(
   ({ content }: { content: string }) => {
+    const hasMath = MATH_RE.test(content);
+
+    if (hasMath) {
+      return (
+        <Suspense>
+          <MathMarkdownBlock content={content} components={markdownComponents} />
+        </Suspense>
+      );
+    }
+
     return (
       <ReactMarkdown
-        remarkPlugins={[remarkGfm, [remarkMath]]}
-        rehypePlugins={[rehypeKatex]}
-        components={{
-          code: ({ node, className, children, ...props }) => {
-            const match = /language-(\w+)/.exec(className || "");
-            const hasNewlines = String(children).includes("\n");
-            const isInline = !match && !hasNewlines;
-
-            if (isInline) {
-              return (
-                <code
-                  className={cn(
-                    "bg-muted rounded px-1.5 py-0.5 font-mono text-xs",
-                  )}
-                  {...props}
-                >
-                  {children}
-                </code>
-              );
-            }
-            return (
-              <CodeBlock
-                language={match ? match[1] : "plaintext"}
-                value={String(children).replace(/\n$/, "")}
-              />
-            );
-          },
-          pre: ({ children }) => <>{children}</>,
-          a: ({ href, children }) => (
-            <Link
-              href={href || "#"}
-              target="_blank"
-              rel="noopener noreferrer"
-              className={`
-                text-primary underline underline-offset-2
-                hover:no-underline
-              `}
-            >
-              {children}
-            </Link>
-          ),
-          table: ({ children }) => (
-            <div className="mb-3 overflow-x-auto">
-              <table className="w-full border-collapse text-sm">
-                {children}
-              </table>
-            </div>
-          ),
-        }}
+        remarkPlugins={[remarkGfm]}
+        components={markdownComponents}
       >
         {content}
       </ReactMarkdown>

--- a/src/features/chat/ui/parts/message-parts.tsx
+++ b/src/features/chat/ui/parts/message-parts.tsx
@@ -1,9 +1,10 @@
 /* eslint-disable react/no-array-index-key */
 "use client";
 
+import dynamic from "next/dynamic";
+
 import type { ExtractToolUIPart, HandoffToolUIPart, ReasoningUIPart, SearchToolUIPart } from "~/features/chat/types";
 
-import { MemoizedMarkdown } from "~/features/chat/components/messages/markdown";
 import { ExtractingSources } from "~/features/chat/components/ui/extracting-sources";
 import { HandingOff } from "~/features/chat/components/ui/handing-off";
 import { ReasoningContent } from "~/features/chat/components/ui/reasoning-content";
@@ -20,6 +21,10 @@ import {
 import { cn } from "~/lib/utils";
 
 import { normalizeExtractToolPart, normalizeHandoffToolPart, normalizeReasoningText, normalizeSearchToolPart } from "./normalize";
+
+const MemoizedMarkdown = dynamic(
+  () => import("~/features/chat/components/messages/markdown").then(mod => mod.MemoizedMarkdown),
+);
 
 export type RenderState = {
   isLast: boolean;


### PR DESCRIPTION
This PR guts Marked in favor of handling more markdown parsing ourselves. This is both a bundle size save and a performance save. Based on my testing, I didn't see any major issues between this and the previous rendition.