### PR TITLE
feat(settings): move encryption key rotation to auth danger zone

### DIFF
--- a/src/features/settings/components/sections/data-management-section.tsx
+++ b/src/features/settings/components/sections/data-management-section.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { useQueryClient } from "@tanstack/react-query";
-import { KeyRoundIcon, Trash2Icon } from "lucide-react";
-import { useState } from "react";
+import { Trash2Icon } from "lucide-react";
 import { toast } from "sonner";
 
 import { Button } from "~/components/ui/button";
@@ -14,23 +13,6 @@ import { SettingsSection } from "../ui/settings-section";
 
 export function DataManagementSection() {
   const queryClient = useQueryClient();
-  const [isRotating, setIsRotating] = useState(false);
-
-  const handleRotateKey = async () => {
-    setIsRotating(true);
-    try {
-      const res = await fetch("/api/settings/rotate-key", { method: "POST" });
-      if (!res.ok)
-        throw new Error("Failed to rotate key");
-      toast.success("Encryption key rotated successfully");
-    }
-    catch {
-      toast.error("Failed to rotate encryption key");
-    }
-    finally {
-      setIsRotating(false);
-    }
-  };
 
   const handleDeleteAllThreads = async () => {
     const { deletedCount } = await deleteAllThreads();
@@ -43,47 +25,25 @@ export function DataManagementSection() {
       title="Data Management"
       description="Manage your thread data and history."
     >
-      <div className="space-y-4">
-        <div className="space-y-2">
-          <ConfirmationDialog
-            trigger={(
-              <Button variant="outline" className="w-full" disabled={isRotating}>
-                <KeyRoundIcon className="size-4" />
-                {isRotating ? "Rotating..." : "Rotate Encryption Key"}
-              </Button>
-            )}
-            title="Rotate Encryption Key"
-            description="This will generate a new encryption key and re-encrypt all your thread messages. This may take a moment."
-            icon={KeyRoundIcon}
-            confirmLabel="Rotate Key"
-            loadingLabel="Rotating..."
-            onConfirm={handleRotateKey}
-          />
-          <p className="text-muted-foreground text-xs">
-            Rotate encryption key and re-encrypt thread messages.
-          </p>
-        </div>
-
-        <div className="space-y-2">
-          <ConfirmationDialog
-            trigger={(
-              <Button variant="destructive" className="w-full">
-                <Trash2Icon className="size-4" />
-                Delete All Threads
-              </Button>
-            )}
-            title="Delete All Threads"
-            description="This will permanently delete all your threads and messages. This action cannot be undone."
-            icon={Trash2Icon}
-            confirmLabel="Delete All Threads"
-            loadingLabel="Deleting..."
-            onConfirm={handleDeleteAllThreads}
-            variant="destructive"
-          />
-          <p className="text-muted-foreground text-xs">
-            Permanently delete all your thread history.
-          </p>
-        </div>
+      <div className="space-y-2">
+        <ConfirmationDialog
+          trigger={(
+            <Button variant="destructive" className="w-full">
+              <Trash2Icon className="size-4" />
+              Delete All Threads
+            </Button>
+          )}
+          title="Delete All Threads"
+          description="This will permanently delete all your threads and messages. This action cannot be undone."
+          icon={Trash2Icon}
+          confirmLabel="Delete All Threads"
+          loadingLabel="Deleting..."
+          onConfirm={handleDeleteAllThreads}
+          variant="destructive"
+        />
+        <p className="text-muted-foreground text-xs">
+          Permanently delete all your thread history.
+        </p>
       </div>
     </SettingsSection>
   );

--- a/src/features/settings/components/sections/delete-account-section.tsx
+++ b/src/features/settings/components/sections/delete-account-section.tsx
@@ -1,15 +1,54 @@
 "use client";
 
-import { TriangleAlertIcon } from "lucide-react";
+import { Button, Card, Flex, Grid, Inset, Text } from "@radix-ui/themes";
+import { KeyRoundIcon, Trash2Icon, TriangleAlertIcon } from "lucide-react";
+import { useState } from "react";
 import { toast } from "sonner";
 
-import { Button } from "~/components/ui/button";
 import { deleteAccount } from "~/features/auth/actions";
 
 import { ConfirmationDialog } from "../ui/confirmation-dialog";
 import { SettingsSection } from "../ui/settings-section";
 
+function IconPanel({ children }: { children?: React.ReactNode }) {
+  return (
+    <Flex
+      width="32px"
+      height="32px"
+      align="center"
+      justify="center"
+      style={{
+        borderWidth: 1,
+        borderStyle: "solid",
+        borderColor: "var(--gray-4)",
+        borderRadius: "var(--radius-3)",
+        backgroundColor: "var(--gray-2)",
+      }}
+    >
+      {children}
+    </Flex>
+  );
+}
+
 export function DeleteAccountSection() {
+  const [isRotating, setIsRotating] = useState(false);
+
+  const handleRotateKey = async () => {
+    setIsRotating(true);
+    try {
+      const res = await fetch("/api/settings/rotate-key", { method: "POST" });
+      if (!res.ok)
+        throw new Error("Failed to rotate key");
+      toast.success("Encryption key rotated successfully");
+    }
+    catch {
+      toast.error("Failed to rotate encryption key");
+    }
+    finally {
+      setIsRotating(false);
+    }
+  };
+
   const handleDeleteAccount = async () => {
     try {
       await deleteAccount();
@@ -22,28 +61,70 @@ export function DeleteAccountSection() {
   };
 
   return (
-    <SettingsSection title="Danger Zone" variant="danger">
-      <div className="space-y-2">
-        <ConfirmationDialog
-          trigger={(
-            <Button variant="destructive" className="w-full">
-              Delete Account
-            </Button>
-          )}
-          title="Delete Account"
-          description="This action cannot be undone. All your data, including threads, settings, and preferences will be permanently deleted."
-          icon={TriangleAlertIcon}
-          confirmationType="text"
-          confirmText="DELETE"
-          confirmLabel="Delete Account"
-          loadingLabel="Deleting..."
-          onConfirm={handleDeleteAccount}
-          variant="destructive"
-        />
-        <p className="text-muted-foreground text-xs">
-          Permanently delete your account and all associated data.
-        </p>
-      </div>
+    <SettingsSection title="Danger Zone" description="Irreversible and destructive actions." variant="danger">
+      <Card size="2">
+        <Inset side="all" clip="padding-box">
+          <Inset side="x" px="current" className="woswidgets-card-list-item" clip="padding-box">
+            <Grid columns="auto 1fr auto" align="center" gap="4" px="4" py="4">
+              <IconPanel>
+                <KeyRoundIcon className="size-4" style={{ color: "var(--gray-11)" }} />
+              </IconPanel>
+              <Flex direction="column">
+                <Text size="2" highContrast weight="bold" as="p" mb="-2px">
+                  Encryption Key
+                </Text>
+                <Text size="2" color="gray">
+                  Generate a new key and re-encrypt all thread messages.
+                </Text>
+              </Flex>
+              <ConfirmationDialog
+                trigger={(
+                  <Button highContrast variant="surface" color="gray" disabled={isRotating}>
+                    {isRotating ? "Rotating..." : "Rotate Key"}
+                  </Button>
+                )}
+                title="Rotate Encryption Key"
+                description="This will generate a new encryption key and re-encrypt all your thread messages. This may take a moment."
+                icon={KeyRoundIcon}
+                confirmLabel="Rotate Key"
+                loadingLabel="Rotating..."
+                onConfirm={handleRotateKey}
+              />
+            </Grid>
+          </Inset>
+          <Inset side="x" px="current" className="woswidgets-card-list-item" clip="padding-box">
+            <Grid columns="auto 1fr auto" align="center" gap="4" px="4" py="4">
+              <IconPanel>
+                <Trash2Icon className="size-4" style={{ color: "var(--gray-11)" }} />
+              </IconPanel>
+              <Flex direction="column">
+                <Text size="2" highContrast weight="bold" as="p" mb="-2px">
+                  Delete Account
+                </Text>
+                <Text size="2" color="gray">
+                  Permanently delete your account and all associated data.
+                </Text>
+              </Flex>
+              <ConfirmationDialog
+                trigger={(
+                  <Button variant="solid" color="red">
+                    Delete Account
+                  </Button>
+                )}
+                title="Delete Account"
+                description="This action cannot be undone. All your data, including threads, settings, and preferences will be permanently deleted."
+                icon={TriangleAlertIcon}
+                confirmationType="text"
+                confirmText="DELETE"
+                confirmLabel="Delete Account"
+                loadingLabel="Deleting..."
+                onConfirm={handleDeleteAccount}
+                variant="destructive"
+              />
+            </Grid>
+          </Inset>
+        </Inset>
+      </Card>
     </SettingsSection>
   );
 }


### PR DESCRIPTION
Small change to move the key re-roll stuff to `Auth` and make styling consistent.

## Key Changes
- Move encryption key reroll from data-management-section to delete-account-section under Danger Zone
- Restyle danger zone using Radix Themes components (Card, Grid, Inset, Button, Text) to match WorkOS styling
- Add IconPanel matching WorkOS widget icon treatment
- Remove encryption key rotation from data-management-section