### PR TITLE
chat: optimise initial chat creation logic

### DIFF
--- a/src/app/(main)/authenticated-home.tsx
+++ b/src/app/(main)/authenticated-home.tsx
@@ -3,8 +3,7 @@
 import type { UseChatHelpers } from "@ai-sdk/react";
 
 import { useRouter } from "next/navigation";
-import { use, useCallback, useState } from "react";
-import { toast } from "sonner";
+import { use, useCallback } from "react";
 
 import type { ChatUIMessage } from "~/features/chat/types";
 import type { UserSettingsData } from "~/features/settings/types";
@@ -13,10 +12,8 @@ import type { ThreadIcon } from "~/lib/db/schema/chat";
 import { BetaBanner } from "~/features/chat/components/beta-banner";
 import { ChatInput } from "~/features/chat/components/chat-input";
 import { LandingPageContent } from "~/features/chat/components/landing/landing-page-content";
-import { useCreateThread } from "~/features/chat/hooks/use-threads";
 import { useChatUIStore } from "~/features/chat/store";
 import { UserSettingsContext } from "~/features/settings/settings-context";
-import { UpgradePromptDialog } from "~/features/subscriptions/components/upgrade-prompt-dialog";
 
 const FALLBACK_SETTINGS: Pick<UserSettingsData, "defaultThreadName" | "defaultThreadIcon" | "landingPageContent"> = {
   defaultThreadName: "New Thread",
@@ -30,12 +27,6 @@ export function AuthenticatedHome(): React.ReactNode {
   const router = useRouter();
   const input = useChatUIStore(state => state.input);
   const setInput = useChatUIStore(state => state.setInput);
-  const createThread = useCreateThread();
-  const [upgradeDialog, setUpgradeDialog] = useState<{ open: boolean; currentUsage: number; limit: number }>({
-    open: false,
-    currentUsage: 0,
-    limit: 0,
-  });
 
   const handleSuggestionClick = useCallback((suggestion: string) => {
     setInput(suggestion);
@@ -43,64 +34,27 @@ export function AuthenticatedHome(): React.ReactNode {
 
   const handleSendMessage: UseChatHelpers<ChatUIMessage>["sendMessage"] = async (messageParts) => {
     const threadId = crypto.randomUUID();
-
     sessionStorage.setItem(`initial_${threadId}`, JSON.stringify(messageParts));
-
     router.push(`/chat/${threadId}`);
-
-    createThread.mutate(
-      { threadId, title: resolvedSettings.defaultThreadName, icon: resolvedSettings.defaultThreadIcon },
-      {
-        onError: (error) => {
-          if (
-            error
-            && typeof error === "object"
-            && "code" in error
-            && error.code === "THREAD_LIMIT_EXCEEDED"
-            && "currentUsage" in error
-            && "limit" in error
-          ) {
-            setUpgradeDialog({
-              open: true,
-              currentUsage: error.currentUsage as number,
-              limit: error.limit as number,
-            });
-          }
-          else {
-            const message = error instanceof Error ? error.message : "Failed to create thread";
-            toast.error(message);
-          }
-        },
-      },
-    );
   };
 
   const showLandingPage = !input.trim() && resolvedSettings.landingPageContent !== "blank";
 
   return (
-    <>
-      <div className="flex h-full max-h-screen flex-col">
-        <BetaBanner />
-        <div className="min-h-0 flex-1 overflow-auto">
-          <LandingPageContent
-            type={resolvedSettings.landingPageContent}
-            isVisible={showLandingPage}
-            onSuggestionClickAction={handleSuggestionClick}
-          />
-        </div>
-        <div className="shrink-0">
-          <ChatInput
-            sendMessage={handleSendMessage}
-            isLoading={createThread.isPending}
-          />
-        </div>
+    <div className="flex h-full max-h-screen flex-col">
+      <BetaBanner />
+      <div className="min-h-0 flex-1 overflow-auto">
+        <LandingPageContent
+          type={resolvedSettings.landingPageContent}
+          isVisible={showLandingPage}
+          onSuggestionClickAction={handleSuggestionClick}
+        />
       </div>
-      <UpgradePromptDialog
-        open={upgradeDialog.open}
-        onOpenChangeAction={open => setUpgradeDialog(prev => ({ ...prev, open }))}
-        currentUsage={upgradeDialog.currentUsage}
-        limit={upgradeDialog.limit}
-      />
-    </>
+      <div className="shrink-0">
+        <ChatInput
+          sendMessage={handleSendMessage}
+        />
+      </div>
+    </div>
   );
 }

--- a/src/app/(main)/chat/[id]/chat-thread.tsx
+++ b/src/app/(main)/chat/[id]/chat-thread.tsx
@@ -17,6 +17,7 @@ import { isInsufficientCreditsError, parseAIError } from "~/features/chat/lib/pa
 import { useChatUIStore } from "~/features/chat/store";
 import { getModelCapabilities, useFavoriteModels } from "~/features/models";
 import { OPENROUTER_CREDITS_KEY } from "~/features/settings/hooks/use-user-settings";
+import { UpgradePromptDialog } from "~/features/subscriptions/components/upgrade-prompt-dialog";
 
 type ChatThreadProps = {
   params: Promise<{ id: string }>;
@@ -42,6 +43,11 @@ function ChatThread({ params, initialMessages, initialPendingMessage, parentThre
   } = useChatUIStore();
 
   const [creditError, setCreditError] = useState<{ messageId: string } | null>(null);
+  const [upgradeDialog, setUpgradeDialog] = useState<{ open: boolean; currentUsage: number; limit: number }>({
+    open: false,
+    currentUsage: 0,
+    limit: 0,
+  });
 
   // Rehydrate model selector from thread's last-used model
   const hasRehydratedModelRef = useRef(false);
@@ -127,6 +133,22 @@ function ChatThread({ params, initialMessages, initialPendingMessage, parentThre
       if (isInsufficientCreditsError(error)) {
         setCreditError({ messageId: lastSendMessageId ?? "" });
         return;
+      }
+
+      // Check for thread limit exceeded
+      try {
+        const errorData = JSON.parse(error.message);
+        if (errorData.code === "THREAD_LIMIT_EXCEEDED") {
+          setUpgradeDialog({
+            open: true,
+            currentUsage: errorData.currentUsage,
+            limit: errorData.limit,
+          });
+          return;
+        }
+      }
+      catch {
+        // Not a JSON error, continue with default handling
       }
 
       toast.error(friendlyMessage);
@@ -314,26 +336,34 @@ function ChatThread({ params, initialMessages, initialPendingMessage, parentThre
   }, [setLastSendMessageId]);
 
   return (
-    <ChatView
-      messages={messages}
-      sendMessage={sendMessage}
-      isLoading={isLoading}
-      onStop={handleStop}
-      threadId={id}
-      parentThread={parentThread}
-    >
-      <ChatMessages
+    <>
+      <ChatView
         messages={messages}
+        sendMessage={sendMessage}
         isLoading={isLoading}
-        onRegenerate={handleRegenerate}
-        isRegenerating={isRegenerating}
-        onEditMessage={handleEditMessage}
-        isEditSubmitting={isEditSubmitting}
-        creditError={creditError}
-        onRetryCreditError={handleRetryCreditError}
-        onDismissCreditError={handleDismissCreditError}
+        onStop={handleStop}
+        threadId={id}
+        parentThread={parentThread}
+      >
+        <ChatMessages
+          messages={messages}
+          isLoading={isLoading}
+          onRegenerate={handleRegenerate}
+          isRegenerating={isRegenerating}
+          onEditMessage={handleEditMessage}
+          isEditSubmitting={isEditSubmitting}
+          creditError={creditError}
+          onRetryCreditError={handleRetryCreditError}
+          onDismissCreditError={handleDismissCreditError}
+        />
+      </ChatView>
+      <UpgradePromptDialog
+        open={upgradeDialog.open}
+        onOpenChangeAction={open => setUpgradeDialog(prev => ({ ...prev, open }))}
+        currentUsage={upgradeDialog.currentUsage}
+        limit={upgradeDialog.limit}
       />
-    </ChatView>
+    </>
   );
 }
 

--- a/src/app/(main)/chat/[id]/page.tsx
+++ b/src/app/(main)/chat/[id]/page.tsx
@@ -1,4 +1,3 @@
-import type { UIMessage } from "ai";
 import type { Metadata } from "next";
 
 import { redirect } from "next/navigation";
@@ -27,24 +26,32 @@ export default async function ChatServer({ params }: ChatServerProps) {
     redirect("/");
   }
 
-  // Fetch thread, messages, and parent thread in parallel
-  const [thread, initialMessages, parentThread] = await Promise.all([
-    getThreadById(id),
-    getMessagesByThreadId(id),
-    getParentThread(id),
-  ]);
+  const thread = await getThreadById(id);
 
-  // If thread exists, verify ownership
-  // If thread doesn't exist, allow access - it will be created on-demand by the chat API
-  // (This supports optimistic navigation where client navigates before server creates thread)
-  if (thread && thread.userId !== session.user.id) {
+  // New thread fast-path: skip pointless DB queries for threads that don't exist yet
+  if (!thread) {
+    return (
+      <ChatThread
+        params={Promise.resolve({ id })}
+        initialMessages={[]}
+        initialPendingMessage={null}
+        parentThread={null}
+        lastUsedModelId={null}
+        initialThread={null}
+      />
+    );
+  }
+
+  // Existing thread: verify ownership
+  if (thread.userId !== session.user.id) {
     redirect("/");
   }
 
-  // Note: Initial message is now retrieved on the client side from sessionStorage
-  // to avoid URL length limits. This is only passed to the component as null here.
-  // The client component (chat-thread.tsx) will retrieve it from sessionStorage.
-  const initialPendingMessage: UIMessage | null = null;
+  // Fetch messages and parent thread in parallel
+  const [initialMessages, parentThread] = await Promise.all([
+    getMessagesByThreadId(id),
+    getParentThread(id),
+  ]);
 
   // Derive the last-used model from the most recent user message that has a modelId
   const lastUsedModelId = initialMessages
@@ -56,24 +63,20 @@ export default async function ChatServer({ params }: ChatServerProps) {
     <ChatThread
       params={Promise.resolve({ id })}
       initialMessages={initialMessages}
-      initialPendingMessage={initialPendingMessage}
+      initialPendingMessage={null}
       parentThread={parentThread}
       lastUsedModelId={lastUsedModelId}
-      initialThread={
-        thread
-          ? {
-              id: thread.id,
-              title: thread.title,
-              icon: thread.icon,
-              lastMessageAt: thread.lastMessageAt?.toISOString() ?? null,
-              userId: thread.userId,
-              createdAt: thread.createdAt.toISOString(),
-              updatedAt: thread.updatedAt.toISOString(),
-              isShared: false,
-              tags: [],
-            }
-          : null
-      }
+      initialThread={{
+        id: thread.id,
+        title: thread.title,
+        icon: thread.icon,
+        lastMessageAt: thread.lastMessageAt?.toISOString() ?? null,
+        userId: thread.userId,
+        createdAt: thread.createdAt.toISOString(),
+        updatedAt: thread.updatedAt.toISOString(),
+        isShared: false,
+        tags: [],
+      }}
     />
   );
 }

--- a/src/features/chat/hooks/use-threads.ts
+++ b/src/features/chat/hooks/use-threads.ts
@@ -8,9 +8,8 @@ import { useMemo } from "react";
 import type { GroupedThreads, TagGroup } from "~/features/chat/utils/thread-grouper";
 import type { ThreadIcon } from "~/lib/db/schema/chat";
 
-import { archiveThread, createNewThread, deleteThread, fetchThreadStats, regenerateThreadIcon, regenerateThreadName, renameThread, setThreadIcon } from "~/features/chat/actions";
+import { archiveThread, deleteThread, fetchThreadStats, regenerateThreadIcon, regenerateThreadName, renameThread, setThreadIcon } from "~/features/chat/actions";
 import { groupThreadsByDate, groupThreadsByTag } from "~/features/chat/utils/thread-grouper";
-import { SUBSCRIPTION_KEY } from "~/features/subscriptions/hooks/use-subscription";
 import { ARCHIVED_THREADS_KEY, THREADS_KEY } from "~/lib/queries/query-keys";
 
 export { ARCHIVED_THREADS_KEY, THREADS_KEY };
@@ -30,12 +29,6 @@ export type ThreadFromApi = {
 type ThreadsResponse = {
   threads: ThreadFromApi[];
   nextCursor: string | null;
-};
-
-type CreateThreadInput = {
-  threadId: string;
-  title?: string;
-  icon?: ThreadIcon;
 };
 
 async function fetchThreads({ pageParam, archived, tagIds, search }: { pageParam: string | undefined; archived?: boolean; tagIds?: string[]; search?: string }): Promise<ThreadsResponse> {
@@ -103,73 +96,6 @@ export function useThreads(options: { enabled?: boolean; archived?: boolean; tag
     data: groupedThreads,
     tagGroups,
   };
-}
-
-export type ThreadLimitError = {
-  error: string;
-  code: "THREAD_LIMIT_EXCEEDED";
-  currentUsage: number;
-  limit: number;
-};
-
-export function useCreateThread() {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: async (input: CreateThreadInput) => {
-      const result = await createNewThread({ threadId: input.threadId, title: input.title, icon: input.icon });
-      if ("error" in result) {
-        throw result;
-      }
-      return result.threadId;
-    },
-    onMutate: async (input) => {
-      await queryClient.cancelQueries({ queryKey: THREADS_KEY });
-
-      const previous = queryClient.getQueryData<InfiniteData<ThreadsResponse>>(THREADS_KEY);
-
-      const now = new Date().toISOString();
-      const optimisticThread: ThreadFromApi = {
-        id: input.threadId,
-        title: input.title || "New Thread",
-        icon: input.icon ?? null,
-        lastMessageAt: now,
-        userId: "",
-        createdAt: now,
-        updatedAt: now,
-        isShared: false,
-        tags: [],
-      };
-
-      queryClient.setQueryData<InfiniteData<ThreadsResponse>>(THREADS_KEY, (old) => {
-        if (!old) {
-          return {
-            pages: [{ threads: [optimisticThread], nextCursor: null }],
-            pageParams: [undefined],
-          };
-        }
-
-        const [first, ...rest] = old.pages;
-        const withoutDup = first.threads.filter(t => t.id !== input.threadId);
-
-        return {
-          ...old,
-          pages: [{ ...first, threads: [optimisticThread, ...withoutDup] }, ...rest],
-        };
-      });
-
-      return { previous };
-    },
-    onError: (_err, _input, context) => {
-      if (context?.previous) {
-        queryClient.setQueryData(THREADS_KEY, context.previous);
-      }
-    },
-    onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: THREADS_KEY });
-      queryClient.invalidateQueries({ queryKey: SUBSCRIPTION_KEY });
-    },
-  });
 }
 
 export function useThreadTitle(threadId: string, options: { initialThread?: ThreadFromApi | null } = {}): string | undefined {

--- a/src/features/chat/queries.ts
+++ b/src/features/chat/queries.ts
@@ -432,6 +432,76 @@ export async function ensureThreadExists(
 }
 
 /**
+ * Ensure a thread exists for a user, creating it if missing.
+ * Includes subscription-based thread limit check before creation.
+ *
+ * @param threadId ID of the thread
+ * @param userId ID of the user
+ * @param title Optional title for new threads
+ */
+export async function ensureThreadExistsWithLimitCheck(
+  threadId: string,
+  userId: string,
+  title?: string,
+): Promise<
+  | { ok: true; exists: boolean; owned: boolean; created: boolean }
+  | { ok: false; reason: string; currentUsage: number; limit: number }
+> {
+  const existing = await db
+    .select({ id: threads.id, userId: threads.userId })
+    .from(threads)
+    .where(eq(threads.id, threadId))
+    .limit(1);
+
+  if (existing.length > 0) {
+    return {
+      ok: true,
+      exists: true,
+      owned: existing[0].userId === userId,
+      created: false,
+    };
+  }
+
+  // Thread doesn't exist - check limit and create
+  return db.transaction(async (tx) => {
+    const subRow = await tx
+      .select({ tier: subscriptions.tier })
+      .from(subscriptions)
+      .where(eq(subscriptions.userId, userId))
+      .limit(1);
+
+    const tier = subRow[0]?.tier ?? "free";
+    const threadLimit = TIER_LIMITS[tier].threads;
+
+    const threadCountResult = await tx
+      .select({ count: count() })
+      .from(threads)
+      .where(eq(threads.userId, userId));
+
+    const currentCount = threadCountResult[0]?.count ?? 0;
+
+    if (threadLimit !== null && currentCount >= threadLimit) {
+      return {
+        ok: false as const,
+        reason: `You've reached your limit of ${threadLimit} threads. Delete some threads or upgrade to continue.`,
+        currentUsage: currentCount,
+        limit: threadLimit,
+      };
+    }
+
+    const now = new Date();
+    await tx.insert(threads).values({
+      id: threadId,
+      userId,
+      title: title || "New Thread",
+      lastMessageAt: now,
+    });
+
+    return { ok: true as const, exists: true, owned: true, created: true };
+  });
+}
+
+/**
  * Get a thread by ID with basic info
  * Cached per-request using React cache() for deduplication.
  *

--- a/src/features/chat/server/handler.ts
+++ b/src/features/chat/server/handler.ts
@@ -3,7 +3,7 @@ import { createUIMessageStream, createUIMessageStreamResponse, NoSuchToolError }
 import type { ChatUIMessage } from "~/features/chat/types";
 import type { ApiKeyProvider } from "~/lib/api-keys/types";
 
-import { ensureThreadExists, renameThreadById, saveMessage, updateThreadIcon } from "~/features/chat/queries";
+import { ensureThreadExistsWithLimitCheck, renameThreadById, saveMessage, updateThreadIcon } from "~/features/chat/queries";
 import { formatProviderError } from "~/features/chat/server/error";
 import { streamChatResponse } from "~/features/chat/server/service";
 import { generateThreadMetadata } from "~/features/chat/server/thread";
@@ -39,14 +39,26 @@ export async function handleChatRequest({ req, userId }: { req: Request; userId:
   const baseModelId = modelId || "google/gemini-3-flash-preview";
 
   const [threadStatus, { settings, resolvedKeys }] = await Promise.all([
-    threadId ? ensureThreadExists(threadId, userId) : Promise.resolve(null),
+    threadId ? ensureThreadExistsWithLimitCheck(threadId, userId) : Promise.resolve(null),
     getUserSettingsAndKeys(userId, clientKeys),
   ]);
 
   const openrouterKey = resolvedKeys.openrouter;
   const parallelKey = searchEnabled ? resolvedKeys.parallel : undefined;
 
-  if (threadStatus && !threadStatus.owned) {
+  if (threadStatus && !threadStatus.ok) {
+    return new Response(JSON.stringify({
+      error: threadStatus.reason,
+      code: "THREAD_LIMIT_EXCEEDED",
+      currentUsage: threadStatus.currentUsage,
+      limit: threadStatus.limit,
+    }), {
+      status: 403,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  if (threadStatus && threadStatus.ok && !threadStatus.owned) {
     return new Response(JSON.stringify({ error: "Thread not found or unauthorized" }), {
       status: 403,
       headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
- Moves thread creation and limit checks from the client to the server
- UI for handling thread limit errors is now only shown in the chat thread view, not on the home page
- Removed unused thread-creation logic from client hooks and components
- Added a new server-side function `ensureThreadExistsWithLimitCheck` that checks the user's thread limit before creating a new thread, and returns a structured error if the limit is exceeded
  - Updated the chat API handler to use this new function, and to return a 403 error with relevant details if the thread limit is reached
- Removed all direct thread creation logic and related error handling from the `AuthenticatedHome` component and `use-threads` hook
- Moved the thread limit upgrade dialog UI to the `ChatThread` component, so users only see upgrade prompts when sending a message in a new thread and the limit is exceeded
- Optimized the chat thread page server component to avoid unnecessary database queries for new threads that do not exist yet, supporting faster navigation and reducing load